### PR TITLE
fix: Timestamps

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <meta name="twitter:description" content="Evidence, links, and community actions regarding GPL compliance for the Centauri Carbon firmware.">
     <meta name="twitter:image" content="https://freethecode.lol/assets/images/cat-sunglasses.png">
 
-
+    <!-- Scripts -->
     <script src="script.js" defer></script>
   </head>
   <body>
@@ -478,7 +478,8 @@ ELEGOO Support Team
 
       <div class="glass-card" id="updates">
         <h2><span class="emoji">🆕</span> Latest Updates</h2>
-        <p class="footer-note last-update">Page last updated: August 31, 2025 | Issue ongoing since August 7, 2025</p>
+        <div class="last-update"></div>
+      </br>
         <ul>
           <li>Clarified: binary blobs are not a GPL‑3.0 workaround; complete corresponding source is required for modified Klipper.</li>
           <li>Community notes potential fraud concerns from past denials; some consider FTC/state reports.</li>
@@ -619,7 +620,6 @@ Sincerely,
           >klipper3d.org</a
         >.
       </p>
-      <p class="footer-note">Page last updated: August 31, 2025 | Issue ongoing since August 7, 2025</p>
       <p class="footer-subnote">
         Thank you to all community contributors who made this effort possible 💜
       </p>

--- a/index.html
+++ b/index.html
@@ -478,7 +478,6 @@ ELEGOO Support Team
 
       <div class="glass-card" id="updates">
         <h2><span class="emoji">🆕</span> Latest Updates</h2>
-        <div class="last-update"></div>
       </br>
         <ul>
           <li>Clarified: binary blobs are not a GPL‑3.0 workaround; complete corresponding source is required for modified Klipper.</li>
@@ -621,6 +620,7 @@ Sincerely,
         >.
       </p>
       <p class="footer-subnote">
+        <div class="last-update"></div>
         Thank you to all community contributors who made this effort possible 💜
       </p>
       <div class="info footer-info" id="traffic-note">

--- a/script.js
+++ b/script.js
@@ -241,7 +241,7 @@ initializeTheme();
   // === Get GitHub commit timestamp ===
   async function getLastCommitDate() {
     try {
-      const res = await fetch("https://api.github.com/repos/botflakes/free-the-code/commits/beta-fixes");
+      const res = await fetch("https://api.github.com/repos/Delulu-Delilah/free-the-code/commits/beta-fixes");
       const data = await res.json();
       return new Date(data.commit.author.date);
     } catch (err) {


### PR DESCRIPTION
Timestamps are now being pulled directly via the GitHub API (see script.js) in the footer. So they should update automatically from here on out (fingers crossed 🤞).