### PR TITLE
Add lite and mobile stylesheets, enable Lite Mode toggle

### DIFF
--- a/PROPOSED_CHANGES.md
+++ b/PROPOSED_CHANGES.md
@@ -12,49 +12,58 @@ Replace the introductory paragraph under the `Industry Context` card with:
 </p>
 ```
 
-### 1a) Bambu item — re-add as “ecosystem restrictions” (not GPL)
-Insert this list item in the Industry Context list (suggested position: after the Marlin/Linux derivatives item):
+### 1a) Bambu item — for future discussion only (not part of this PR)
+Keep this snippet here only for potential future use. Do not include it in this PR.
 
 ```html
+<!-- NOT FOR THIS PR: Bambu ecosystem restrictions example -->
 <li>
   <strong>Bambu Lab (ecosystem restrictions):</strong> Recent firmware introduced an authorization control system that blocks custom firmware and restricts third‑party slicers from wireless transfers. "Bambu Connect" provides a limited bridge; community notes reduced direct access and accessory compatibility.
-  </li>
+</li>
 ```
 
 ### 2) Chitu Systems involvement — expand Industry bullet
-Replace the existing `Chitu‑supplied platforms` list item under Industry Context with the following to broaden scope and note proprietary ecosystems:
+Replace the existing `Chitu‑supplied platforms` list item under Industry Context with the following to broaden scope and note proprietary ecosystems. Language is qualified and includes citation placeholders:
 
 ```html
 <li>
-  <strong>Chitu‑supplied platforms:</strong> Shared firmware stacks used across brands (e.g., Anycubic; some Creality models historically) have led to shipments that include modified GPL components without corresponding source. Supplier contracts do not remove the distributor’s GPL obligations. Chitu Systems' firmware and hardware are proprietary, which can constrain user modification and repairability.
+  <strong>Chitu‑supplied platforms:</strong> Shared firmware stacks used across brands (e.g., Anycubic; some Creality models historically) have, in some cases, resulted in distributions missing corresponding source for modified GPL components <!-- add citations -->. Supplier contracts do not remove the distributor’s GPL obligations. Chitu Systems' firmware and hardware are proprietary, which can constrain user modification and repairability.
 </li>
 ```
 
 ### 3) Legal & Policy — adjust “Chitu involvement” bullet
-Replace the `Chitu involvement` bullet with this copy to capture supplier dynamics and historical Creality usage:
+Replace the `Chitu involvement` bullet with this copy to capture supplier dynamics and historical Creality usage (with citation placeholders):
 
 ```html
-<li><strong>Chitu involvement:</strong> Code suggests Chitu involvement and similarities to Anycubic Kobra 2 Pro; some Creality models have historically used Chitu platforms. This affects who receives compliance requests and clarifies that OEM/supplier contracts do not negate GPL obligations.</li>
+<li><strong>Chitu involvement:</strong> Analysis suggests Chitu involvement with similarities to Anycubic Kobra 2 Pro <!-- add citation -->; some Creality models historically used Chitu platforms. This clarifies who should receive compliance requests and that OEM/supplier contracts do not negate GPL obligations.</li>
 ```
 
 ### 4) Updates — expand Chitu note
-Replace the existing Chitu-related update with the following (you can later append a verified model list):
+Replace the existing Chitu-related update with the following. Track specific model listing as a TODO in the repo, not in shipped copy:
 
 ```html
-<li>Chitu likely involved; similarities to Anycubic Kobra 2 Pro firmware observed; note: some Creality models have historically used Chitu‑supplied platforms [add specific model list once verified].</li>
+<li>Chitu involvement likely; similarities to Anycubic Kobra 2 Pro firmware observed <!-- add citation -->; note: some Creality models historically used Chitu‑supplied platforms.</li>
 ```
 
 ### 5) Evidence/Issue — add vendor statement clarification (optional)
-Add this info box either at the end of `The Issue` card or at the top of `Technical Evidence` to acknowledge public statements vs. community findings:
+Add this info box either at the end of `The Issue` card or at the top of `Technical Evidence` to acknowledge public statements vs. community findings. Keep the tone neutral and add a citation placeholder:
 
 ```html
 <div class="info">
-  <strong>Vendor statement:</strong> Elegoo has publicly stated that the Centauri Carbon OS is not based on Klipper. This page aggregates community technical evidence indicating Klipper‑based components and modifications; if confirmed, GPL‑3.0 requires providing the complete corresponding source to users of the distributed binaries.
+  <strong>Vendor statement:</strong> Elegoo has publicly stated that the Centauri Carbon OS is not based on Klipper <!-- add citation -->. This page aggregates community technical indicators of Klipper‑based components and modifications. If confirmed, GPL‑3.0 requires providing the complete corresponding source to users of the distributed binaries.
 </div>
 ```
 
-### Sources for context
-- Hackster review note (Elegoo statement): [Elegoo Centauri Carbon 3D printer review](https://www.hackster.io/news/elegoo-centauri-carbon-3d-printer-review-c57caab085e1)
-- Chitu proprietary ecosystem context: [Chitu Systems and CHITUBOX: a lesson in fighting open‑source 3D printing](https://3dprintingindustry.com/news/chitu-systems-and-chitubox-a-lesson-in-fighting-open-source-3d-printing-194783/)
+### Sources for context (add archival links where possible)
+- Hackster review note (Elegoo statement): [Elegoo Centauri Carbon 3D printer review](https://www.hackster.io/news/elegoo-centauri-carbon-3d-printer-review-c57caab085e1) • archive: <!-- add archive link -->
+- Chitu proprietary ecosystem context: [Chitu Systems and CHITUBOX: a lesson in fighting open‑source 3D printing](https://3dprintingindustry.com/news/chitu-systems-and-chitubox-a-lesson-in-fighting-open-source-3d-printing-194783/) • archive: <!-- add archive link -->
+
+### Optional link hardening in Good Actors section
+If desired, replace plain names with official links:
+
+```html
+<li><strong><a href="https://www.prusa3d.com/" target="_blank" rel="noopener noreferrer">Prusa Research</a></strong> — Open‑source printers, firmware, and PrusaSlicer; strong community engagement and documentation.</li>
+<li><strong><a href="https://lulzbot.com/" target="_blank" rel="noopener noreferrer">LulzBot (FAME 3D)</a></strong> — Historically 100% open‑source; robust printers that encourage user modification.</li>
+```
 
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     />
     <title>PSA: Elegoo Centauri Carbon & GPL Compliance</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles-lite.css" media="(max-width: 640px) or (prefers-reduced-motion: reduce)" id="liteStylesheet">
+    <link rel="stylesheet" href="styles-mobile.css" media="only screen and (max-width: 480px)">
     <link rel="icon" type="image/png" href="assets/icons/elegoo-logo.png">
     <link rel="canonical" href="https://freethecode.lol/">
     <meta name="description" content="A community effort aggregating evidence, context, and actions to ensure GPL compliance for the Elegoo Centauri Carbon firmware.">
@@ -194,7 +196,7 @@
             GPL on multiple libraries including Klipper
           </li>
           <li>
-            <strong>Chitu-supplied platforms:</strong> Shared firmware stacks used across brands (e.g., Anycubic; Creality on some models historically) have led to shipments that include modified GPL components without corresponding source. Supplier contracts do not remove the distributor’s GPL obligations.
+            <strong>Chitu-supplied platforms:</strong> Shared firmware stacks used across brands (e.g., Anycubic; some Creality models historically) have, in some cases, resulted in distributions missing corresponding source for modified GPL components (<a href="https://en.wikipedia.org/wiki/Creality" target="_blank" rel="noopener noreferrer">source</a>). Supplier contracts do not remove the distributor’s GPL obligations (<a href="https://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank" rel="noopener noreferrer">GPL‑3.0</a>). Chitu Systems' firmware and hardware are proprietary, which can constrain user modification and repairability (<a href="https://3dprintingindustry.com/news/chitu-systems-and-chitubox-a-lesson-in-fighting-open-source-3d-printing-194783/" target="_blank" rel="noopener noreferrer">context</a>).
           </li>
           <li>
             <strong>Historical cases:</strong> Community reports cite GPL gaps on specific models (e.g., Creality CR‑X), while other products later published sources (e.g., Creality K1 series).
@@ -209,6 +211,10 @@
           hold manufacturers accountable. GPL violations harm innovation,
           security, and user rights across the entire ecosystem.
         </div>
+
+        <div class="info">
+          <strong>Vendor statement:</strong> Elegoo has publicly stated that the Centauri Carbon OS is not based on Klipper (<a href="https://www.hackster.io/news/elegoo-centauri-carbon-3d-printer-review-c57caab085e1" target="_blank" rel="noopener noreferrer">source</a>). This page aggregates community technical indicators of Klipper‑based components and modifications. If confirmed, GPL‑3.0 requires providing the complete corresponding source to users of the distributed binaries (<a href="https://www.gnu.org/licenses/gpl-3.0.en.html" target="_blank" rel="noopener noreferrer">GPL‑3.0</a>).
+        </div>
       </div>
 
       <div class="glass-card" id="legal">
@@ -222,7 +228,7 @@
           <li><strong>Fraud and consumer protection:</strong> Misrepresentations (e.g., denying Klipper use) may create consumer fraud exposure; some users consider FTC/state reports.</li>
           <li><strong>Chargebacks (use cautiously):</strong> Some banks may accept disputes for deceptive practices. Risk: loss of support or future purchases.</li>
           <li><strong>International enforcement:</strong> GPL has seen international enforcement, including in China. For imported hardware, U.S. courts can issue border injunctions.</li>
-          <li><strong>Chitu involvement:</strong> Code suggests Chitu involvement and similarities to Anycubic Kobra 2 Pro; some Creality models have historically used Chitu platforms. This impacts who should receive compliance requests.</li>
+          <li><strong>Chitu involvement:</strong> Analysis suggests Chitu involvement with similarities to Anycubic Kobra 2 Pro (<a href="https://www.reddit.com/r/3Dprinting/comments/1n1rlmc/klipper_on_the_centauri_carbon_i_need_your_help/" target="_blank" rel="noopener noreferrer">community analysis</a>, <a href="https://github.com/OpenCentauri/OpenCentauri/tree/main/serial-multiplexer" target="_blank" rel="noopener noreferrer">repo</a>); some Creality models historically used Chitu platforms (<a href="https://en.wikipedia.org/wiki/Creality" target="_blank" rel="noopener noreferrer">source</a>). This informs where to direct compliance requests.</li>
         </ul>
         <p style="opacity:.8">These points reflect community discussion and are not legal advice.</p>
       </div>
@@ -476,7 +482,7 @@ ELEGOO Support Team
           <li>Community notes potential fraud concerns from past denials; some consider FTC/state reports.</li>
           <li>Some users weighing chargebacks; caution: this can impact future support/purchases.</li>
           <li>Discussion on international enforcement and possible border injunctions for non‑compliant imports.</li>
-          <li>Chitu likely involved; similarities to Anycubic Kobra 2 Pro firmware observed; note: some Creality models have historically used Chitu-supplied platforms.</li>
+          <li>Chitu involvement likely; similarities to Anycubic Kobra 2 Pro firmware observed (<a href="https://www.reddit.com/r/3Dprinting/comments/1n1rlmc/klipper_on_the_centauri_carbon_i_need_your_help/" target="_blank" rel="noopener noreferrer">community analysis</a>); note: some Creality models historically used Chitu‑supplied platforms (<a href="https://en.wikipedia.org/wiki/Creality" target="_blank" rel="noopener noreferrer">source</a>).</li>
           <li>Links added: Reddit context, Hackster review, OctoEverywhere mention, Rossmann wiki suggestion.</li>
           <li>Workarounds: Raspberry Pi host possible via <a href="https://github.com/OpenCentauri/OpenCentauri/tree/main/serial-multiplexer" target="_blank" rel="noopener noreferrer">serial‑multiplexer</a>, MCU side remains challenging.</li>
           <li>New Reddit thread highlights: broken WebUI during prints; reports of thermal‑runaway risk on 1.1.25; excessive network traffic; community demand for source to enable community fixes and OpenNept4une‑like progress; confirmation that Klippy is transpiled to C++ and modified.</li>
@@ -614,6 +620,9 @@ Sincerely,
       <p class="footer-subnote">
         <div class="last-update"></div>
         Thank you to all community contributors who made this effort possible 💜
+      </p>
+      <p class="footer-subnote">
+        <button id="lite-toggle" type="button" aria-pressed="false">Enable Lite Mode</button>
       </p>
       <div class="info footer-info" id="traffic-note">
         <strong>Note:</strong> A related but separate network traffic issue was discovered where the Centauri Carbon generates excessive data usage (70GB+ per month while idle). This has been moved to a <a href="https://redd.it/1mbhnmn" target="_blank" rel="noopener noreferrer">separate discussion thread</a> to keep the GPL compliance issue focused.

--- a/styles-lite.css
+++ b/styles-lite.css
@@ -1,0 +1,78 @@
+/* Lite stylesheet: minimal effects for slower devices */
+/* Strategy: reduce shadows, blur, animations, transitions, fixed backgrounds, and heavy layout effects. */
+
+:root {
+  --lite-transition: none !important;
+  --lite-shadow: none !important;
+  --lite-blur: 0 !important;
+}
+
+/* Disable global animations/transitions where possible */
+* {
+  animation: none !important;
+  transition: none !important;
+  scroll-behavior: auto !important;
+}
+
+/* Ensure base elements remain visible without animations */
+body { opacity: 1 !important; }
+.glass-card { opacity: 1 !important; transform: none !important; }
+
+/* Containers */
+.glass-container, .glass-card, .nav-menu, .toc {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  box-shadow: none !important;
+  background: rgba(20,20,20,0.9) !important;
+}
+
+/* Images */
+img { filter: none !important; }
+
+/* Navigation */
+.nav-menu { position: sticky !important; top: 0; z-index: 1000; }
+.nav-links { transition: none !important; }
+.nav-toggle { min-width: 44px; min-height: 44px; background: rgba(255,255,255,0.14); border-radius: 12px; }
+.nav-toggle::after { content: 'Menu'; margin-left: 0.25rem; color: #fff; font-size: 0.95rem; }
+.nav-brand { transform: none !important; }
+
+/* Particles disabled by CSS fallback */
+.particle { display: none !important; }
+
+/* Carousels become simple scroll areas */
+.carousel-container {
+  scroll-behavior: auto !important;
+}
+
+/* Hover scaling disabled */
+.nav-link, .glass-card, .support-badge, .contributor-category {
+  transform: none !important;
+}
+
+/* Reduce padding/margins slightly */
+.glass-card { padding: 1rem !important; margin: 0.75rem 0 !important; }
+.hero-content { padding: 1rem !important; }
+
+/* Typography tweaks if needed */
+body { line-height: 1.4; }
+
+/* Utility: hide heavy decorative backgrounds if present */
+body::before, body::after { display: none !important; }
+
+/* Disable shine/sheen pseudo-elements and related animations */
+.glass-card::before,
+.glass-card::after,
+.highlight::before,
+.warning::before,
+.info::before,
+.gratitude::before,
+header::before,
+.nav-link::before,
+.email-template::before {
+  display: none !important;
+  animation: none !important;
+  transition: none !important;
+  content: none !important;
+}
+
+

--- a/styles-mobile.css
+++ b/styles-mobile.css
@@ -1,0 +1,39 @@
+/* Mobile-specific styles (<=480px). Keep fast and minimal. */
+
+/* Typography and spacing */
+html { font-size: 15px; }
+body { line-height: 1.5; padding-top: 72px; }
+
+/* Layout simplifications */
+.layout { display: block; padding: 0 0.75rem; }
+.toc { position: static; margin: 0 0 1rem 0; padding: 1rem; }
+section { padding: 0; margin: 1rem auto; }
+
+/* Cards */
+.glass-card { padding: 1rem; margin: 0.75rem 0; border-radius: 12px; }
+.highlight, .warning, .info, .gratitude { padding: 1.25rem; margin: 1.25rem 0; }
+
+/* Header */
+header { margin: 1rem 0.5rem; padding: 1.5rem 1rem; }
+.hero-content { padding: 0; }
+h1 { font-size: 2rem; }
+h2 { font-size: 1.5rem; }
+
+/* Navigation */
+.nav-container { padding: 0 0.75rem; }
+.nav-links { gap: 1rem; }
+.nav-link { padding: 0.5rem 0.75rem; }
+.nav-toggle span { width: 22px; }
+/* Increase tap target and add label contrast */
+.nav-toggle { min-width: 48px; min-height: 48px; background: rgba(255,255,255,0.12); }
+.nav-toggle::after { content: 'Menu'; margin-left: 0.25rem; color: #fff; font-size: 0.95rem; }
+/* Keep top bar sticky on phones */
+.nav-menu { position: sticky; top: 0; z-index: 1000; }
+
+/* Contributors & support grids */
+.community-support, .contributors-grid { grid-template-columns: 1fr; gap: 0.75rem; }
+.support-badge, .contributor-category { padding: 1rem; }
+
+/* Footer */
+footer { padding: 2rem 1rem; }
+

--- a/styles.css
+++ b/styles.css
@@ -225,18 +225,38 @@ body::before {
 
 .nav-toggle {
   display: none;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
   cursor: pointer;
-  padding: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  min-width: 44px;
+  min-height: 44px;
+  border: 1px solid var(--border-default);
+  border-radius: 12px;
+  background: rgba(255,255,255,0.08);
+  box-shadow: var(--shadow-sm);
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
 .nav-toggle span {
-  width: 25px;
+  width: 26px;
   height: 3px;
   background: #fff;
   margin: 3px 0;
   transition: all 0.3s ease;
   border-radius: 2px;
+  box-shadow: 0 1px 0 rgba(0,0,0,0.25);
+}
+
+.nav-toggle:hover { background: rgba(255,255,255,0.16); transform: translateY(-1px); }
+.nav-toggle:active { transform: translateY(0); }
+.nav-toggle::after {
+  content: 'Menu';
+  color: var(--text-primary);
+  font-weight: var(--font-weight-medium);
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
 }
 
 /* Smooth Scrolling */


### PR DESCRIPTION
Introduces styles-lite.css and styles-mobile.css for improved performance and accessibility on slower devices and mobile screens. Updates index.html to include these stylesheets and adds a Lite Mode toggle button. Enhances script.js to support Lite Mode, disabling animations and effects when enabled, and auto-enables Lite Mode on low-powered devices. Refines Chitu-related content and vendor statement in PROPOSED_CHANGES.md and index.html for clarity and citation. Updates styles.css and navigation for better mobile usability.